### PR TITLE
Handle dataset loading if schema check fails

### DIFF
--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -730,12 +730,12 @@ def main(args: FlatArguments):
 
                 dfs = []
                 reader = (
-                    pd.read_json 
+                    partial(pd.read_json , lines=True)
                     if args.train_file_type == 'json'
-                    else pd.read_parquet
+                    else partial(pd.read_parquet, engine='auto')
                 )
                 for file in train_files:
-                    dfs.append(reader(file, lines=True, orient='records'))
+                    dfs.append(reader(file, orient='records'))
 
                 raw_datasets = datasets.DatasetDict({
                     'train': datasets.Dataset.from_pandas(pd.concat(dfs))

--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -27,6 +27,7 @@ from datetime import timedelta
 from functools import partial
 from typing import List, Optional, Union
 
+import pandas as pd
 import datasets
 import deepspeed
 import torch
@@ -697,7 +698,7 @@ def main(args: FlatArguments):
             configs=args.dataset_config_name,
             splits=["train"],
             save_data_dir=args.dataset_mix_dir if accelerator.is_main_process else None,
-            columns_to_keep=["messages"],
+            columns_to_keep=["messages","tools","documents"],
         )
     elif args.dataset_mixer_list is not None:
         # mixing datasets via config
@@ -706,19 +707,41 @@ def main(args: FlatArguments):
             configs=args.dataset_config_name,
             splits=["train"],
             save_data_dir=args.dataset_mix_dir if accelerator.is_main_process else None,
-            columns_to_keep=["messages"],
+            columns_to_keep=["messages","tools","documents"],
         )
     else:
         data_files = {}
         dataset_args = {}
         if args.train_file is not None:
             data_files["train"] = args.train_file
-        with accelerator.main_process_first():
-            raw_datasets = load_dataset(
-                args.train_file_type,
-                data_files=data_files,
-                **dataset_args,
-            )
+        with accelerator.main_process_first():            
+            try:
+                raw_datasets = load_dataset(
+                    args.train_file_type,
+                    data_files=data_files,
+                    **dataset_args,
+                )
+            except:
+                # - load_dataset sometimes has strict schema
+                # checks and may fail on tools / documents
+                train_files = args.train_file
+                if isinstance(train_files, str):
+                    train_files = [train_files]
+
+                dfs = []
+                reader = (
+                    pd.read_json 
+                    if args.train_file_type == 'json'
+                    else pd.read_parquet
+                )
+                for file in train_files:
+                    dfs.append(reader(file, lines=True, orient='records'))
+
+                raw_datasets = datasets.DatasetDict({
+                    'train': datasets.Dataset.from_pandas(pd.concat(dfs))
+                })
+                del df
+                del dfs
 
     # Load pretrained model and tokenizer
     if args.config_name:


### PR DESCRIPTION
changes from @Swanand

`load_dataset` has strict schema checks, that may fail when tools and documents are added. This adds a workaround to load the dataset in pandas, and then create the dataset object