### PR TITLE
Script for Data Loading Testing

### DIFF
--- a/open_instruct/dpo_tune.py
+++ b/open_instruct/dpo_tune.py
@@ -632,7 +632,9 @@ def main(args: FlatArguments):
                     quantization_config=bnb_config,
                     device_map=device_map,
                     torch_dtype=torch.bfloat16,
-                    use_flash_attention_2=True if args.use_flash_attn else False,
+                    attn_implementation="flash_attention_2"
+                    if args.use_flash_attn
+                    else "eager",
                 )
             else:
                 model = AutoModelForCausalLM.from_pretrained(
@@ -642,7 +644,9 @@ def main(args: FlatArguments):
                     config=config,
                     trust_remote_code=args.trust_remote_code,
                     low_cpu_mem_usage=args.low_cpu_mem_usage,
-                    use_flash_attention_2=True if args.use_flash_attn else False,
+                    attn_implementation="flash_attention_2"
+                    if args.use_flash_attn
+                    else "eager",
                 )
         else:
             logger.info("Training new model from scratch")

--- a/open_instruct/dpo_tune_cache.py
+++ b/open_instruct/dpo_tune_cache.py
@@ -646,7 +646,9 @@ def main(args: FlatArguments):
                     quantization_config=bnb_config,
                     device_map=device_map,
                     torch_dtype=torch.bfloat16,
-                    use_flash_attention_2=True if args.use_flash_attn else False,
+                    attn_implementation="flash_attention_2"
+                    if args.use_flash_attn
+                    else "eager",
                 )
             else:
                 model = AutoModelForCausalLM.from_pretrained(
@@ -656,7 +658,9 @@ def main(args: FlatArguments):
                     config=config,
                     trust_remote_code=args.trust_remote_code,
                     low_cpu_mem_usage=args.low_cpu_mem_usage,
-                    use_flash_attention_2=True if args.use_flash_attn else False,
+                    attn_implementation="flash_attention_2"
+                    if args.use_flash_attn
+                    else "eager",
                 )
         else:
             logger.info("Training new model from scratch")

--- a/open_instruct/dpo_tune_cache.py
+++ b/open_instruct/dpo_tune_cache.py
@@ -405,8 +405,35 @@ class FlatArguments:
             raise ValueError("Need either a dataset name, dataset mixer, or a training file.")
         else:
             if self.train_file is not None:
-                extension = self.train_file.split(".")[-1]
-                assert extension in ["json", "jsonl"], "`train_file` should be a json or a jsonl file."
+                if os.path.isdir(self.train_file):
+                    # just assume they 
+                    self.train_file = [
+                        os.path.join(self.train_file, x)
+                        for x in os.listdir(self.train_file)
+                    ]
+                    self.train_file_type = [
+                        x.split(".")[-1] for x in self.train_file
+                    ]
+                    self.train_file_type = [
+                        x for x in self.train_file_type 
+                        if x in ["json", "jsonl", "parquet"]
+                    ]
+                    self.train_file_type = list(set(self.train_file_type)) # unique
+                    # assume the directory cannot mix types
+                    self.train_file_type = (
+                        None if len(self.train_file_type) == 0 else 
+                        self.train_file_type[0]
+                    )
+                else:
+                    self.train_file_type = self.train_file.split(".")[-1]
+
+                # some slight renames
+                if self.train_file_type == 'jsonl':
+                    self.train_file_type = "json"
+                
+                assert self.train_file_type in ["json", "parquet"], (
+                    "`train_file` should be a json(l) or parquet file."
+                )
         if (
             (self.dataset_name is not None and (self.dataset_mixer is not None or self.dataset_mixer_list is not None))
             or (self.dataset_name is not None and self.train_file is not None)
@@ -456,6 +483,7 @@ def get_cache_ref_logprobs(
     resume_step: int,
     epoch_range: range,
     forward_fn: Callable,
+    use_lora: bool = False,
 ):
     epoch_cached_reference_chosen_logps = []
     epoch_cached_reference_rejected_logps = []
@@ -468,7 +496,7 @@ def get_cache_ref_logprobs(
         cached_reference_rejected_logps = []
         with torch.no_grad():
             for step, batch in tqdm(enumerate(active_dataloader), disable=not accelerator.is_local_main_process):
-                if args.use_lora:
+                if use_lora:
                     with accelerator.unwrap_model(model).disable_adapter():
                         reference_chosen_logps, reference_rejected_logps, _ = forward_fn(
                             model, batch, average_log_prob=average_log_prob
@@ -575,7 +603,7 @@ def main(args: FlatArguments):
         if args.train_file is not None:
             data_files["train"] = args.train_file
         raw_datasets = load_dataset(
-            "json",
+            args.train_file_type,
             data_files=data_files,
             **dataset_args,
         )
@@ -964,6 +992,7 @@ def main(args: FlatArguments):
             resume_step,
             range(starting_epoch, args.num_train_epochs),
             forward_fn,
+            args.use_lora,
         )
         print("=============after cache logprobs")
         print_gpu_stats(init_gpu_memory)

--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -472,9 +472,13 @@ class FlatArguments:
                     )
                 else:
                     self.train_file_type = self.train_file.split(".")[-1]
+
+                # some slight renames
+                if self.train_file_type == 'jsonl':
+                    self.train_file_type = "json"
                 
-                assert self.train_file_type in ["json", "jsonl", "parquet"], (
-                    "`train_file` should be a json or a jsonl or parquet file."
+                assert self.train_file_type in ["json", "parquet"], (
+                    "`train_file` should be a json(l) or parquet file."
                 )
         if (
             (

--- a/scripts/test_dataloading.py
+++ b/scripts/test_dataloading.py
@@ -1,60 +1,36 @@
-from open_instruct.finetune import main
-import importlib
+import torch
+import os
 
-from typing import Any
 from unittest.mock import patch, Mock
 from accelerate import Accelerator
 
-def patch_target_module(
-    to_patch: str,
-    replace_with: Any,
-    target_module: str = None,
-):
-    to_patch = to_patch.split(".")
-    assert len(to_patch) > 1, "must have an object to patch"
 
-    to_patch, obj_name_to_patch = to_patch[:-1], to_patch[-1]
-    to_patch = ".".join(to_patch)
-    source = importlib.import_module(to_patch)
-    original_obj = getattr(source, obj_name_to_patch)
-    setattr(source, obj_name_to_patch, replace_with)
-
-    if target_module is not None:
-        # reload and this should get the patched object
-        target_module = importlib.import_module(target_module)
-        importlib.reload(target_module)
-
-        # replace it
-        setattr(source, obj_name_to_patch, original_obj)
-
-class DummyAccelerator:
-
-    def __init__(*args, **kwargs):
-        pass
-
-
-from transformers import AutoModelForCausalLM, AutoConfig
+from transformers import AutoModelForCausalLM
 from accelerate import init_empty_weights
-from accelerate.state import AcceleratorState
-from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
+from transformers.modeling_outputs import CausalLMOutputWithPast
 
-# MODEL_CONFIG = None
-# def from_pretrained(model_name_or_path, *args, **kwargs):
-#     global MODEL_CONFIG
-#     MODEL_CONFIG = AutoConfig.from_pretrained(model_name_or_path)
-#     return Mock()
 from types import MethodType
 
 STORE = []
 
+# builds the from_pretrained to pass through AutoModelForCausalLM
+# - loads the model on the meta device
+
 def built_from_pretrained():
 
     def forward(self, input_ids, *args, **kwargs):
-        STORE.append(input_ids)
+        # - hook to capture the input_ids
+        STORE.append({
+            'input_ids': input_ids,
+            'labels': kwargs.get('labels'),
+        })
+
+        # - returns dummy outputs / loss
         return CausalLMOutputWithPast(
             loss=torch.tensor(0.),
         )
 
+    # mock the from_pretrained function
     old_func = AutoModelForCausalLM.from_pretrained
     def _from_pretrained(model_name_or_path, *args, **kwargs):
         with init_empty_weights():
@@ -66,14 +42,11 @@ def built_from_pretrained():
 
     return _from_pretrained
 
-patch_transformers = patch.multiple(
-    AutoModelForCausalLM,
-    # from_pretrained=Mock(),
-    from_pretrained=built_from_pretrained(),
-)
-
 def accelerate_prepare(self, model, optimizer, dataloader, scheduler):
     self.state = Mock() # sneak it in
+
+    # skip through the set_epoch if the train loop assumes a distributed
+    # dataloader
 
     def set_epoch(self, *args):
         pass
@@ -81,7 +54,12 @@ def accelerate_prepare(self, model, optimizer, dataloader, scheduler):
     dataloader.set_epoch = MethodType(set_epoch, dataloader)
     return model, optimizer, dataloader, scheduler
 
-import torch
+# - patches
+
+patch_transformers = patch.multiple(
+    AutoModelForCausalLM,
+    from_pretrained=built_from_pretrained(),
+)
 
 patch_accelerate = patch.multiple(
     Accelerator,
@@ -93,21 +71,44 @@ patch_accelerate = patch.multiple(
     sync_gradients=False,
 )
 
-# patch_accelerate_state = patch.multiple(
-#     AcceleratorState,
-#     fsdp_plugin=Mock(),
-# )
+PATCHES = [
+    patch_transformers,
+    patch_accelerate,
+]
 
-# import deepspeed
-# import torch
-# 
-# def deepspeed_enter(*args, **kargs):
-#     MODEL_CONFIG.
-#     return torch.nn.Embedding(
-# 
-#     )
-# 
-# patch_deepspeed = patch.multiple(
-#     deepspeed.zero.GatheredParameters,
-#     __enter__=
-# )
+def test_finetune(
+    model_name_or_path: str,
+    train_file: str,
+    max_train_steps: int = 2,
+    write_data_to_directory: str = None,
+):
+    from open_instruct.finetune import main, FlatArguments
+    from contextlib import ExitStack
+
+    args = FlatArguments(
+        model_name_or_path=model_name_or_path,
+        train_file=train_file,
+        push_to_hub=False,
+        try_launch_beaker_eval_jobs=False,
+        output_dir=None,
+        max_train_steps=max_train_steps,
+    )
+
+    # clear the store
+    STORE.clear()
+    with ExitStack() as stack:
+        for patch in PATCHES:
+            stack.enter_context(patch)
+        main(args)
+
+    if write_data_to_directory is None:
+        return STORE
+
+    os.makedirs(write_data_to_directory)
+    for i, data in enumerate(STORE):
+        torch.save(data, os.path.join(write_data_to_directory, f'batch_{i}.pt'))
+
+if __name__ == "__main__":
+    import fire
+    data = fire.Fire(test_finetune)
+    

--- a/scripts/test_dataloading.py
+++ b/scripts/test_dataloading.py
@@ -116,7 +116,43 @@ def test_finetune(
         ),
     )
 
-    test_tuning_script(
+    return test_tuning_script(
+        main, args,
+        [
+            patch_transformers,
+            patch_accelerate,
+        ],
+        STORE,
+        write_data_to_directory,
+    )
+
+def test_dpo_tune(
+    model_name_or_path: str,
+    train_file: str,
+    max_train_steps: int = 2,
+    write_data_to_directory: str = None,
+):
+    from open_instruct.dpo_tune import main, FlatArguments
+
+    args = FlatArguments(
+        model_name_or_path=model_name_or_path,
+        train_file=train_file,
+        push_to_hub=False,
+        try_launch_beaker_eval_jobs=False,
+        output_dir=None,
+        max_train_steps=max_train_steps,
+    )
+
+    # - initialize store in transformers patcher
+    STORE = []
+    patch_transformers = patch.multiple(
+        AutoModelForCausalLM,
+        from_pretrained=built_from_pretrained(
+            STORE
+        ),
+    )
+
+    return test_tuning_script(
         main, args,
         [
             patch_transformers,

--- a/scripts/test_dataloading.py
+++ b/scripts/test_dataloading.py
@@ -1,0 +1,113 @@
+from open_instruct.finetune import main
+import importlib
+
+from typing import Any
+from unittest.mock import patch, Mock
+from accelerate import Accelerator
+
+def patch_target_module(
+    to_patch: str,
+    replace_with: Any,
+    target_module: str = None,
+):
+    to_patch = to_patch.split(".")
+    assert len(to_patch) > 1, "must have an object to patch"
+
+    to_patch, obj_name_to_patch = to_patch[:-1], to_patch[-1]
+    to_patch = ".".join(to_patch)
+    source = importlib.import_module(to_patch)
+    original_obj = getattr(source, obj_name_to_patch)
+    setattr(source, obj_name_to_patch, replace_with)
+
+    if target_module is not None:
+        # reload and this should get the patched object
+        target_module = importlib.import_module(target_module)
+        importlib.reload(target_module)
+
+        # replace it
+        setattr(source, obj_name_to_patch, original_obj)
+
+class DummyAccelerator:
+
+    def __init__(*args, **kwargs):
+        pass
+
+
+from transformers import AutoModelForCausalLM, AutoConfig
+from accelerate import init_empty_weights
+from accelerate.state import AcceleratorState
+from transformers.modeling_outputs import BaseModelOutputWithPast, CausalLMOutputWithPast
+
+# MODEL_CONFIG = None
+# def from_pretrained(model_name_or_path, *args, **kwargs):
+#     global MODEL_CONFIG
+#     MODEL_CONFIG = AutoConfig.from_pretrained(model_name_or_path)
+#     return Mock()
+from types import MethodType
+
+STORE = []
+
+def built_from_pretrained():
+
+    def forward(self, input_ids, *args, **kwargs):
+        STORE.append(input_ids)
+        return CausalLMOutputWithPast(
+            loss=torch.tensor(0.),
+        )
+
+    old_func = AutoModelForCausalLM.from_pretrained
+    def _from_pretrained(model_name_or_path, *args, **kwargs):
+        with init_empty_weights():
+            model = old_func(
+                model_name_or_path, *args, **kwargs,
+            )
+            model.forward = MethodType(forward, model)
+            return model
+
+    return _from_pretrained
+
+patch_transformers = patch.multiple(
+    AutoModelForCausalLM,
+    # from_pretrained=Mock(),
+    from_pretrained=built_from_pretrained(),
+)
+
+def accelerate_prepare(self, model, optimizer, dataloader, scheduler):
+    self.state = Mock() # sneak it in
+
+    def set_epoch(self, *args):
+        pass
+
+    dataloader.set_epoch = MethodType(set_epoch, dataloader)
+    return model, optimizer, dataloader, scheduler
+
+import torch
+
+patch_accelerate = patch.multiple(
+    Accelerator,
+    wait_for_everyone=Mock(),
+    prepare=accelerate_prepare,
+    num_processes=1,
+    device=torch.device('cuda'),
+    backward=Mock(),
+    sync_gradients=False,
+)
+
+# patch_accelerate_state = patch.multiple(
+#     AcceleratorState,
+#     fsdp_plugin=Mock(),
+# )
+
+# import deepspeed
+# import torch
+# 
+# def deepspeed_enter(*args, **kargs):
+#     MODEL_CONFIG.
+#     return torch.nn.Embedding(
+# 
+#     )
+# 
+# patch_deepspeed = patch.multiple(
+#     deepspeed.zero.GatheredParameters,
+#     __enter__=
+# )


### PR DESCRIPTION
Best way to test the dataloading is to run the actual script (e.g., `finetune`) and then pull out the data samples that is created.
- doing this, we guarantee the samples are created in the same way. 
- we can test this without `torch.distributed`

In this PR we provide
- utilities for extracting data samples from the training script
- a `test_finetune` function (and script) to extract out the data


See the below usage example
```python
from scripts.test_dataloading import test_finetune

data = test_finetune(
    model_name_or_path='/path/to/model/',
    train_file='/path/to/train_file', 
    max_train_steps=2, # number of steps to run
)

```

then we can get the samples from `data[0]`, `data[1]`, and so on

```
# data[0]
{'input_ids': tensor([[100256, 100256, 100256,  ...,  74477,     13, 100257],
         [100256, 100256, 100256,  ...,   8082,     13, 100257],
         [100256, 100256, 100256,  ...,   5687,     13, 100257],
         ...,
         [100256, 100256, 100256,  ...,   3157,     13, 100257],
         [100256, 100256, 100256,  ...,    279,   8712, 100257],
         [100256, 100256, 100256,  ...,  67092,   1210, 100257]]),
 'labels': tensor([[  -100,   -100,   -100,  ...,  74477,     13, 100257],
         [  -100,   -100,   -100,  ...,   8082,     13, 100257],
         [  -100,   -100,   -100,  ...,   5687,     13, 100257],
         ...,
         [  -100,   -100,   -100,  ...,   3157,     13, 100257],
         [  -100,   -100,   -100,  ...,    279,   8712, 100257],
         [  -100,   -100,   -100,  ...,  67092,   1210, 100257]])}
```