### PR TITLE
Padding-Free DPO and Some Updates

### DIFF
--- a/scripts/test_dataloading.py
+++ b/scripts/test_dataloading.py
@@ -140,6 +140,7 @@ def test_dpo_tune(
     train_file: str = None,
     max_train_steps: int = 2,
     write_data_to_directory: str = None,
+    padding_free: bool = False,
 ):
     from open_instruct.dpo_tune_cache import main, FlatArguments
 
@@ -152,6 +153,7 @@ def test_dpo_tune(
         try_auto_save_to_beaker=False,
         output_dir=None,
         max_train_steps=max_train_steps,
+        padding_free=padding_free,
     )
 
     # - initialize store in transformers patcher
@@ -160,7 +162,15 @@ def test_dpo_tune(
         AutoModelForCausalLM,
         from_pretrained=built_from_pretrained(
             STORE,
-            extra_keys=[],
+            extra_keys=[
+                'attention_mask',
+                'cu_seq_lens_q', 
+                'cu_seq_lens_k', 
+                'max_length_q', 
+                'max_length_k', 
+                'position_ids', 
+                'seq_idx'
+            ],
         ),
     )
 


### PR DESCRIPTION
This PR superceeds #8. It setups the padding free for `dpo_tune_cache.py`

TODO:
- handle the non-concatenated case for padding free
- update padding-free tests

## Testing with the DataLoader Tester


```python

from datasets import load_dataset, DatasetDict

# create the dataset
load_dataset('HuggingFaceH4/ultrafeedback_binarized')['train_prefs'].select(range(1000)).to_parquet(
    '../datasets/dpo/ultrafeedback_sample.parquet'
)

from scripts.test_dataloading import test_dpo_tune

data = test_dpo_tune(
    model_name_or_path='...',
    train_file='../datasets/dpo/ultrafeedback_sample.parquet',
    padding_free=True,
)

# data[0]
{'input_ids': tensor([[    27,     91,    882,  ...,    828,     13, 100257]]),
 'attention_mask': None,
 'cu_seq_lens_q': tensor([   0,  451, 1013, 1275, 2848, 2987, 3594, 3652, 4276, 4407, 5007, 5109,
         6654, 6777, 7549, 7612, 8218], dtype=torch.int32),
 'cu_seq_lens_k': tensor([   0,  451, 1013, 1275, 2848, 2987, 3594, 3652, 4276, 4407, 5007, 5109,
         6654, 6777, 7549, 7612, 8218], dtype=torch.int32),
 'max_length_q': 1573,
 'max_length_k': 1573,
 'position_ids': tensor([[  0,   1,   2,  ..., 603, 604, 605]]),
 'seq_idx': tensor([[ 0,  0,  0,  ..., 14, 14, 14]], dtype=torch.int32)}
```