### PR TITLE
Add Span Search Masking Strategy

### DIFF
--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -532,6 +532,10 @@ def encode_sft_example(example, tokenizer, max_seq_length):
     Here, we assume each example has a 'messages' field. Each message in it is a dict with 'role' and 'content' fields.
     We use the `apply_chat_template` function from the tokenizer to tokenize the messages and prepare the input and label tensors.
     """
+    # remove hardcodes later
+    ASST_TAG = [49152, 17594, 49153] # <|start_of_role|>assistant<|end_of_role|>
+    END_TAG = [0] # "<|end_of_text|>"
+
     messages = example["messages"]
 
     additional_inputs = {}
@@ -551,62 +555,34 @@ def encode_sft_example(example, tokenizer, max_seq_length):
         add_generation_prompt=False,
         **additional_inputs,
     )
-    labels = input_ids.clone()
-    # mask the non-assistant part for avoiding loss
-    for message_idx, message in enumerate(messages):
-        if message["role"] != "assistant":
-            # we calculate the start index of this non-assistant message
-            if message_idx == 0:
-                message_start_idx = 0
-            else:
-                message_start_idx = tokenizer.apply_chat_template(
-                    conversation=messages[
-                        :message_idx
-                    ],  # here marks the end of the previous messages
-                    tokenize=True,
-                    return_tensors="pt",
-                    padding=False,
-                    truncation=True,
-                    max_length=max_seq_length,
-                    add_generation_prompt=False,
-                    **additional_inputs,
-                ).shape[1]
-            # next, we calculate the end index of this non-assistant message
-            if (
-                message_idx < len(messages) - 1
-                and messages[message_idx + 1]["role"] == "assistant"
-            ):
-                # for intermediate messages that follow with an assistant message, we need to
-                # set `add_generation_prompt=True` to avoid the assistant generation prefix being included in the loss
-                # (e.g., `<|assistant|>`)
-                message_end_idx = tokenizer.apply_chat_template(
-                    conversation=messages[: message_idx + 1],
-                    tokenize=True,
-                    return_tensors="pt",
-                    padding=False,
-                    truncation=True,
-                    max_length=max_seq_length,
-                    add_generation_prompt=True,
-                    **additional_inputs,
-                ).shape[1]
-            else:
-                # for the last message or the message that doesn't follow with an assistant message,
-                # we don't need to add the assistant generation prefix
-                message_end_idx = tokenizer.apply_chat_template(
-                    conversation=messages[: message_idx + 1],
-                    tokenize=True,
-                    return_tensors="pt",
-                    padding=False,
-                    truncation=True,
-                    max_length=max_seq_length,
-                    add_generation_prompt=False,
-                    **additional_inputs,
-                ).shape[1]
-            # set the label to -100 for the non-assistant part
-            labels[:, message_start_idx:message_end_idx] = -100
-            if max_seq_length and message_end_idx >= max_seq_length:
-                break
+
+    # some prep
+    match = lambda x,y: torch.all(x == y)
+    ASST_TAG = torch.tensor([ASST_TAG])
+    END_TAG = torch.tensor([END_TAG])
+
+    # - prep
     attention_mask = torch.ones_like(input_ids)
+    labels = input_ids.clone()
+
+    # - lengths
+    k, n = ASST_TAG.shape[1], labels.shape[1]
+    k1 = END_TAG.shape[1]
+    
+    if n >= max(k, k1):
+        # - s: start of mask (from after asst response)
+        # - e: end of mask (fassit tag)
+        s, e = 0, None
+        for i in range(k, n):
+
+            if match(input_ids[:, i-k:i], ASST_TAG):
+                labels[:, s:i] = -100 # mask everything from s up to start of asst resp
+                e = i # acts as positional flag that I have found the asst tag
+            elif match(input_ids[:, i-k1:i], END_TAG) and e is not None:
+                # - if e is not None means I have just found the assit tag
+                s = i + 1 # new start should be after the asst resp
+                e = None # reset, this will be set back when find next asst tag
+
     return {
         "input_ids": input_ids.flatten(),
         "labels": labels.flatten(),

--- a/tests/test_chat_template.py
+++ b/tests/test_chat_template.py
@@ -1,98 +1,30 @@
 import pytest
 
 from open_instruct.finetune import masking_strategy_span_search
-from open_instruct.dataset_processor import CHAT_TEMPLATES
 from transformers import AutoTokenizer
 from typing import List
 
+MSG_SYSTEM = { 'role': 'system', 'content': 'This is an system.' }
+MSG_USER_1 = { 'role': 'user', 'content': 'This is an instruction.' }
+MSG_USER_2 = { 'role': 'user', 'content': 'This is another instruction.' }
+MSG_ASST_1 = { 'role': 'assistant', 'content': 'This is a response.' }
+MSG_ASST_2 = { 'role': 'assistant', 'content': 'This is another response.' }
+MSG_ASST_THINK_1 = { 'role': 'assistant', 'content': '<think> I am thinking. </think> This is a response.' }
+MSG_ASST_THINK_2 = { 'role': 'assistant', 'content': '<think> I am thinking again. </think> This is another response.' }
+MSG_TOOL = { 'role': 'tool', 'content': 'this is a response from tool' }
+
 EXAMPLES = {
     'single-turn': {
-        'messages': [
-            {
-                'role': 'user',
-                'content': 'This is an instruction.'
-            },
-            {
-                'role': 'assistant',
-                'content': 'This is a response.'
-            },
-        ]
+        'messages': [ MSG_USER_1, MSG_ASST_1 ]
     },
     'multi-turn': {
-        'messages': [
-            {
-                'role': 'user',
-                'content': 'This is an system.'
-            },
-            {
-                'role': 'user',
-                'content': 'This is an instruction.'
-            },
-            {
-                'role': 'assistant',
-                'content': 'This is a response.'
-            },
-            {
-                'role': 'user',
-                'content': 'This is another instruction.'
-            },
-            {
-                'role': 'assistant',
-                'content': 'This is another response.'
-            },
-        ]
+        'messages': [ MSG_SYSTEM, MSG_USER_1, MSG_ASST_1, MSG_USER_2, MSG_ASST_2 ]
     },
     'multi-turn-with-think': {
-        'messages': [
-            {
-                'role': 'user',
-                'content': 'This is an system.'
-            },
-            {
-                'role': 'user',
-                'content': 'This is a instruction.'
-            },
-            {
-                'role': 'assistant',
-                'content': '<think> I am thinking. </think> This is a response.'
-            },
-            {
-                'role': 'user',
-                'content': 'This is another instruction.'
-            },
-            {
-                'role': 'assistant',
-                'content': '<think> I am thinking again. </think> This is another response.'
-            },
-        ]
+        'messages': [ MSG_SYSTEM, MSG_USER_1, MSG_ASST_THINK_1, MSG_USER_2, MSG_ASST_THINK_2 ]
     },
     'multi-turn-with-think-tools': {
-        'messages': [
-            {
-                'role': 'user',
-                'content': 'This is an system.'
-            },
-            {
-                'role': 'user',
-                'content': 'This is a instruction.'
-            },
-            {
-                'role': 'assistant',
-                'content': '<think> I am thinking. </think> Need to make a tool call.'
-            },
-            {
-                'role': 'tool',
-                'content': 'this is a response from tool'
-            },
-            {
-                'role': 'user',
-                'content': 'This is another instruction.'
-            },
-            {
-                'role': 'assistant',
-                'content': '<think> I am thinking again. </think> This is another response.'
-            },
-        ],
+        'messages': [ MSG_SYSTEM, MSG_USER_1, MSG_ASST_THINK_1, MSG_TOOL, MSG_USER_2, MSG_ASST_THINK_2 ],
         'tools': [
             {'type': 'function'},
         ]
@@ -109,7 +41,7 @@ ANSWERS = {
         'single-turn': [[0, 12]],
         'multi-turn': [[0, 22], [30, 42]],
         'multi-turn-with-think': [[0, 22], [30, 42]],
-        'multi-turn-with-think-tools': [[0, 110], [120, 147]],
+        'multi-turn-with-think-tools': [[0, 105], [113, 140]],
     }
 }
 

--- a/tests/test_chat_template.py
+++ b/tests/test_chat_template.py
@@ -1,0 +1,188 @@
+import pytest
+
+from open_instruct.finetune import masking_strategy_span_search
+from open_instruct.dataset_processor import CHAT_TEMPLATES
+from transformers import AutoTokenizer
+from typing import List
+
+EXAMPLES = {
+    'single-turn': {
+        'messages': [
+            {
+                'role': 'user',
+                'content': 'This is an instruction.'
+            },
+            {
+                'role': 'assistant',
+                'content': 'This is a response.'
+            },
+        ]
+    },
+    'multi-turn': {
+        'messages': [
+            {
+                'role': 'user',
+                'content': 'This is an system.'
+            },
+            {
+                'role': 'user',
+                'content': 'This is an instruction.'
+            },
+            {
+                'role': 'assistant',
+                'content': 'This is a response.'
+            },
+            {
+                'role': 'user',
+                'content': 'This is another instruction.'
+            },
+            {
+                'role': 'assistant',
+                'content': 'This is another response.'
+            },
+        ]
+    },
+    'multi-turn-with-think': {
+        'messages': [
+            {
+                'role': 'user',
+                'content': 'This is an system.'
+            },
+            {
+                'role': 'user',
+                'content': 'This is a instruction.'
+            },
+            {
+                'role': 'assistant',
+                'content': '<think> I am thinking. </think> This is a response.'
+            },
+            {
+                'role': 'user',
+                'content': 'This is another instruction.'
+            },
+            {
+                'role': 'assistant',
+                'content': '<think> I am thinking again. </think> This is another response.'
+            },
+        ]
+    },
+    'multi-turn-with-think-tools': {
+        'messages': [
+            {
+                'role': 'user',
+                'content': 'This is an system.'
+            },
+            {
+                'role': 'user',
+                'content': 'This is a instruction.'
+            },
+            {
+                'role': 'assistant',
+                'content': '<think> I am thinking. </think> Need to make a tool call.'
+            },
+            {
+                'role': 'tool',
+                'content': 'this is a response from tool'
+            },
+            {
+                'role': 'user',
+                'content': 'This is another instruction.'
+            },
+            {
+                'role': 'assistant',
+                'content': '<think> I am thinking again. </think> This is another response.'
+            },
+        ],
+        'tools': [
+            {'type': 'function'},
+        ]
+    },
+}
+
+
+CHAT_TEMPLATE_EXAMPLES = {
+    'thinking': '{%- if tools %}\n    {{- \'<|im_start|>system\\n\' }}\n    {%- if messages[0].role == \'system\' %}\n        {{- messages[0].content + \'\\n\\n\' }}\n    {%- endif %}\n    {{- "# Tools\\n\\nYou may call one or more functions to assist with the user query.\\n\\nYou are provided with function signatures within <tools></tools> XML tags:\\n<tools>" }}\n    {%- for tool in tools %}\n        {{- "\\n" }}\n        {{- tool | tojson }}\n    {%- endfor %}\n    {{- "\\n</tools>\\n\\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\\n<tool_call>\\n{\\"name\\": <function-name>, \\"arguments\\": <args-json-object>}\\n</tool_call><|im_end|>\\n" }}\n{%- else %}\n    {%- if messages[0].role == \'system\' %}\n        {{- \'<|im_start|>system\\n\' + messages[0].content + \'<|im_end|>\\n\' }}\n    {%- endif %}\n{%- endif %}\n{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}\n{%- for message in messages[::-1] %}\n    {%- set index = (messages|length - 1) - loop.index0 %}\n    {%- if ns.multi_step_tool and message.role == "user" and message.content is string and not(message.content.startswith(\'<tool_response>\') and message.content.endswith(\'</tool_response>\')) %}\n        {%- set ns.multi_step_tool = false %}\n        {%- set ns.last_query_index = index %}\n    {%- endif %}\n{%- endfor %}\n{%- for message in messages %}\n    {%- if message.content is string %}\n        {%- set content = message.content %}\n    {%- else %}\n        {%- set content = \'\' %}\n    {%- endif %}\n    {%- if (message.role == "user") or (message.role == "system" and not loop.first) %}\n        {{- \'<|im_start|>\' + message.role + \'\\n\' + content + \'<|im_end|>\' + \'\\n\' }}\n    {%- elif message.role == "assistant" %}\n        {%- set reasoning_content = \'\' %}\n        {%- if message.reasoning_content is string %}\n            {%- set reasoning_content = message.reasoning_content %}\n        {%- else %}\n            {%- if \'</think>\' in content %}\n                {%- set reasoning_content = content.split(\'</think>\')[0].rstrip(\'\\n\').split(\'<think>\')[-1].lstrip(\'\\n\') %}\n                {%- set content = content.split(\'</think>\')[-1].lstrip(\'\\n\') %}\n            {%- endif %}\n        {%- endif %}\n        {%- if loop.index0 > ns.last_query_index %}\n            {%- if loop.last or (not loop.last and reasoning_content) %}\n                {{- \'<|im_start|>\' + message.role + \'\\n<think>\\n\' + reasoning_content.strip(\'\\n\') + \'\\n</think>\\n\\n\' + content.lstrip(\'\\n\') }}\n            {%- else %}\n                {{- \'<|im_start|>\' + message.role + \'\\n\' + content }}\n            {%- endif %}\n        {%- else %}\n            {{- \'<|im_start|>\' + message.role + \'\\n\' + content }}\n        {%- endif %}\n        {%- if message.tool_calls %}\n            {%- for tool_call in message.tool_calls %}\n                {%- if (loop.first and content) or (not loop.first) %}\n                    {{- \'\\n\' }}\n                {%- endif %}\n                {%- if tool_call.function %}\n                    {%- set tool_call = tool_call.function %}\n                {%- endif %}\n                {{- \'<tool_call>\\n{"name": "\' }}\n                {{- tool_call.name }}\n                {{- \'", "arguments": \' }}\n                {%- if tool_call.arguments is string %}\n                    {{- tool_call.arguments }}\n                {%- else %}\n                    {{- tool_call.arguments | tojson }}\n                {%- endif %}\n                {{- \'}\\n</tool_call>\' }}\n            {%- endfor %}\n        {%- endif %}\n        {{- \'<|im_end|>\\n\' }}\n    {%- elif message.role == "tool" %}\n        {%- if loop.first or (messages[loop.index0 - 1].role != "tool") %}\n            {{- \'<|im_start|>user\' }}\n        {%- endif %}\n        {{- \'\\n<tool_response>\\n\' }}\n        {{- content }}\n        {{- \'\\n</tool_response>\' }}\n        {%- if loop.last or (messages[loop.index0 + 1].role != "tool") %}\n            {{- \'<|im_end|>\\n\' }}\n        {%- endif %}\n    {%- endif %}\n{%- endfor %}\n{%- if add_generation_prompt %}\n    {{- \'<|im_start|>assistant\\n\' }}\n    {%- if enable_thinking is defined and enable_thinking is false %}\n        {{- \'<think>\\n\\n</think>\\n\\n\' }}\n    {%- endif %}\n{%- endif %}'
+}
+
+ANSWERS = {
+    ('Qwen/Qwen3-8B', 'thinking'): {
+        'single-turn': [[0, 12]],
+        'multi-turn': [[0, 22], [30, 42]],
+        'multi-turn-with-think': [[0, 22], [30, 42]],
+        'multi-turn-with-think-tools': [[0, 110], [120, 147]],
+    }
+}
+
+@pytest.mark.parametrize(
+    "tokenizer_name,chat_template_name,example_name", 
+    [
+        ('Qwen/Qwen3-8B', 'thinking', 'single-turn'),
+        ('Qwen/Qwen3-8B', 'thinking', 'multi-turn'),
+        ('Qwen/Qwen3-8B', 'thinking', 'multi-turn-with-think'),
+        ('Qwen/Qwen3-8B', 'thinking', 'multi-turn-with-think-tools'),
+    ]
+)
+def test_masking_strategy_span_search(
+    tokenizer_name: str,
+    chat_template_name: str,
+    example_name: List,
+    ignore_label: int = -100,
+):
+    tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
+
+    # patch the chat template
+    tokenizer.chat_template = CHAT_TEMPLATE_EXAMPLES[chat_template_name]
+
+    example = EXAMPLES[example_name]
+
+    input_ids = tokenizer.apply_chat_template(
+        conversation=example['messages'],
+        tokenize=True,
+        return_tensors="pt",
+        padding=False,
+        truncation=True,
+        max_length=1024,
+        add_generation_prompt=False,
+        tools=example.get('tools'),
+        documents=example.get('documents'),
+    )
+
+    # text = tokenizer.decode(input_ids[0])
+
+    labels = masking_strategy_span_search(
+        None,
+        input_ids,
+        tokenizer,
+        asst_tag='<|im_start|>assistant',
+        end_tag='<|im_end|>'
+    )[0]
+
+    spans = []
+    start = False
+    for i in range(len(labels)):
+        if labels[i] == ignore_label and not start:
+            spans.append([i])
+            start = True
+        elif labels[i] != ignore_label and start:
+            spans[-1].append(i)
+            start = False
+
+    for s, e in spans:
+        labels[s:e] = -ignore_label
+
+
+    print('*' * 10, 'original', '*' * 10)
+    print (tokenizer.decode(input_ids[0]))
+    print('*' * 10, 'masked', '*' * 10)
+    print (tokenizer.decode(labels))
+    print('*' * 10, 'spans', '*' * 10)
+    print (spans)
+
+    assert ANSWERS[(
+        tokenizer_name, chat_template_name
+    )][example_name] == spans
+
+    
+
+
+


### PR DESCRIPTION
This PR adds 
1. a new argument `masking_strategy`. For now this can be set to `open_instruct` or `span_search`
2. the span search masking strategy, which requires on specifying two tags
  
i) `asst_tag`: the string that indicates the start of the assistant response
ii) `end_tag`: the string that indicates the end of a turn