### PR TITLE
[2/9] clean_checkpoints_at_end

### DIFF
--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -367,6 +367,12 @@ class FlatArguments:
         default=False,
         metadata={"help": "Whether to use padding-free collation via TensorDataCollatorWithFlattening"},
     )
+    clean_checkpoints_at_end: bool = field(
+        default=False,
+        metadata={
+            "help": "Whether to clean up all previous checkpoints at the end of the run.",
+        },
+    )
 
     def __post_init__(self):
         if self.reduce_loss not in ["mean", "sum"]:
@@ -932,7 +938,7 @@ def main(args: FlatArguments, tc: TokenizerConfig):
         )
 
     # remove all checkpoints to save space
-    if accelerator.is_local_main_process:
+    if args.clean_checkpoints_at_end and accelerator.is_local_main_process:
         clean_last_n_checkpoints(args.output_dir, keep_last_n_checkpoints=0)
 
     if (


### PR DESCRIPTION
Adds the option to save intermediate checkpoints, rather than cleaning them all up at the end. Enable with `--clean_checkpoints_at_end False`.

|   |  PR |                     Title                      |
| - | --- | ---------------------------------------------- |
| 1 | #15 | padding-free                                   |
| 2 | >16 | clean_checkpoints_at_end                       |
| 3 | #17 | final_lr_ratio                                 |
| 4 | #18 | add_seed_and_date_to_run_name                  |
| 5 | #19 | additional_model_arguments                     |
| 6 | #20 | sync_each_batch=True grad acc                  |
| 7 | #21 | no grad acc averaging for sum losses           |
| 8 | #22 | extra reporting                                |
| 9 | #23 | local_main_process_first when building dataset |
