### PR TITLE
[9/9] local_main_process_first when building dataset

### DIFF
--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -544,7 +544,7 @@ def main(args: FlatArguments, tc: TokenizerConfig):
 
     if args.dataset_mixer is not None:
         args.dataset_mixer_list = [item for pair in args.dataset_mixer.items() for item in pair]
-    with accelerator.main_process_first():
+    with accelerator.local_main_process_first():
         transform_fn_args = [
             {"max_seq_length": args.max_seq_length},
             {},


### PR DESCRIPTION
Changes the `main_process_first` ctx manager wrapping data creation to `local_main_process_first`, which is more appropriate for multi-node use cases (and works for single-node as well).

|   |  PR |                     Title                      |
| - | --- | ---------------------------------------------- |
| 1 | #15 | padding-free                                   |
| 2 | #16 | clean_checkpoints_at_end                       |
| 3 | #17 | final_lr_ratio                                 |
| 4 | #18 | add_seed_and_date_to_run_name                  |
| 5 | #19 | additional_model_arguments                     |
| 6 | #20 | sync_each_batch=True grad acc                  |
| 7 | #21 | no grad acc averaging for sum losses           |
| 8 | #22 | extra reporting                                |
| 9 | >23 | local_main_process_first when building dataset |
