### PR TITLE
Fixes: FallBack to LoadDataset, Dup Arguments, Savetensor Saving

### DIFF
--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -100,7 +100,7 @@ def load_dataset(
             'train': Dataset.from_pandas(pd.concat(dfs))
         })
         del df
-        del df
+        del dfs
         return raw_datasets
 
 # ----------------------------------------------------------------------------

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -96,10 +96,7 @@ def load_dataset(
         for file in train_files:
             dfs.append(reader(file, orient='records'))
 
-        raw_datasets = DatasetDict({
-            'train': Dataset.from_pandas(pd.concat(dfs))
-        })
-        del df
+        raw_datasets = Dataset.from_pandas(pd.concat(dfs))
         del dfs
         return raw_datasets
 

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -68,12 +68,12 @@ from transformers.utils.hub import _CACHED_NO_EXIST, TRANSFORMERS_CACHE, extract
 from open_instruct.utils import hf_whoami
 
 # MOVE THIS SOMEWHERE
-from datasets import load_dataset as lds
 def load_dataset(
     *args, **kwargs
 ):
-    import pandas as pd
+    from datasets import load_dataset as lds
     from datasets import DatasetDict
+    import pandas as pd
 
     try:
         return lds(*args, **kwargs)
@@ -97,7 +97,6 @@ def load_dataset(
             dfs.append(reader(file, orient='records'))
 
         raw_datasets = Dataset.from_pandas(pd.concat(dfs))
-        del dfs
         return raw_datasets
 
 # ----------------------------------------------------------------------------

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -84,10 +84,13 @@ def load_dataset(
         if isinstance(train_files, str):
             train_files = [train_files]
 
+        file_type = train_files[0].split('.')[-1]
+        assert file_type in {'json', 'jsonl', 'parquet'}
+
         dfs = []
         reader = (
             partial(pd.read_json , lines=True)
-            if args.train_file_type == 'json'
+            if file_type in {'json', 'jsonl'}
             else partial(pd.read_parquet, engine='auto')
         )
         for file in train_files:

--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -235,7 +235,7 @@ class FlatArguments:
             " Only for linear schedulers, currently."
         },
     )
-    weight_decay: float = field(default=0.0, metadata={"help": "Weight decay for AdamW if we apply some."})
+    
     weight_decay: float = field(default=0.0, metadata={"help": "Weight decay for AdamW if we apply some."})
     timeout: int = field(
         default=1800,
@@ -291,10 +291,7 @@ class FlatArguments:
     load_balancing_weight: float = field(
         default=0.5, metadata={"help": "Weight for load balancing loss if applicable."}
     )
-    clean_checkpoints_at_end: bool = field(
-        default=True, metadata={"help": "Whether to clean up all previous checkpoints at the end of the run."}
-    )
-
+    
     # Experiment tracking
     with_tracking: bool = False
     """If toggled, this experiment will be tracked with Weights and Biases"""
@@ -341,13 +338,7 @@ class FlatArguments:
             "help": "Whether to clean up all previous checkpoints at the end of the run.",
         },
     )
-    final_lr_ratio: Optional[float] = field(
-        default=None,
-        metadata={
-            "help": "Set the final lr value at the end of training to be final_lr_ratio * learning_rate."
-            " Only for linear schedulers, currently."
-        },
-    )
+    
     add_seed_and_date_to_exp_name: bool = True
     additional_model_arguments: Optional[Union[dict, str]] = field(
         default_factory=dict,

--- a/open_instruct/model_utils.py
+++ b/open_instruct/model_utils.py
@@ -394,6 +394,7 @@ def save_with_accelerate(
     output_dir: str,
     use_lora: bool = False,
     model_attribute_to_save: Optional[str] = None,
+    safe_serialization: bool = True,
 ) -> None:
     """`model_attribute_to_save` is for used to save PPO's policy instead of the full model"""
     # set the generation config to an empty setting to be safe.
@@ -429,13 +430,12 @@ def save_with_accelerate(
         if accelerator.is_main_process:
             unwrapped_model.save_pretrained(output_dir, state_dict=state_dict)
     else:
-        # don't use safetensors for saving for now
         unwrapped_model.save_pretrained(
             output_dir,
             is_main_process=accelerator.is_main_process,
             save_function=accelerator.save,
             state_dict=state_dict,
-            safe_serialization=False,
+            safe_serialization=safe_serialization,
         )
 
     if accelerator.is_main_process:


### PR DESCRIPTION
Companion PR to #6, and some additional fixes

- `datasets.load_dataset` does a schema check and sometimes may fail on some files. This fallsback to pandas 
- remove duplicated arguments
- make `savetensor` saving as default

~**API CHANGE**:~
~if the dataset has `tools` or `documents` columns in the dataset, add this to the arguments~

<!--
```python
---dataset_target_columns input_ids labels attention_mask tools documents
```
-->