### PR TITLE
Port changes from finetune to DPO

### DIFF
--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -1233,6 +1233,7 @@ TRANSFORM_FNS = {
     "preference_tokenize_v1": (preference_tokenize_v1, "map"),
     "preference_filter_v1": (preference_filter_v1, "filter"),
     "preference_tulu_tokenize_and_truncate_v1": (preference_tulu_tokenize_and_truncate_v1_2, "map"),
+    "preference_span_search_mask_out": (preference_span_search_mask_out, "map"),
     "preference_tulu_filter_v1": (preference_tulu_filter_v1, "filter"),
     "rlvr_tokenize_v1": (rlvr_tokenize_v2, "map"),
     "rlvr_filter_v1": (rlvr_filter_v1, "filter"),

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -1300,6 +1300,9 @@ class DatasetConfig:
         if os.path.exists(self.dataset_name) and self.dataset_name.endswith(".jsonl"):
             assert self.dataset_split == "train", "Only train split is supported for local jsonl files."
             self.dataset = load_dataset("json", data_files=self.dataset_name, split=self.dataset_split)
+        elif os.path.exists(self.dataset_name) and self.dataset_name.endswith(".parquet"):
+            assert self.dataset_split == "train", "Only train split is supported for local parquet files."
+            self.dataset = load_dataset("parquet", data_files=self.dataset_name, split=self.dataset_split)
         else:
             # commit hash only works for hf datasets
             self.dataset_commit_hash = get_commit_hash(

--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -1111,6 +1111,42 @@ def preference_tulu_filter_v1(row: Dict[str, Any], tokenizer: PreTrainedTokenize
     return any(x != -100 for x in row[CHOSEN_LABELS_KEY]) and any(x != -100 for x in row[REJECTED_LABELS_KEY])
 
 
+def preference_span_search_mask_out(
+    row: Dict[str, Any],
+    tokenizer: PreTrainedTokenizer,
+    max_seq_length: int,
+    chosen_key: str = DEFAULT_CHOSEN_KEY,
+    rejected_key: str = DEFAULT_REJECTED_KEY,
+):
+    """
+    Here we assume each example has a rejected and chosen field, both of which are a list of messages.
+    Each message is a dict with 'role' and 'content' fields.
+    We assume only the last message is different, and the prompt is contained in the list of messages.
+    """
+    chosen_messages = row[chosen_key]
+    rejected_messages = row[rejected_key]
+    if len(chosen_messages) == 0:
+        raise ValueError("chosen messages field is empty.")
+    if len(rejected_messages) == 0:
+        raise ValueError("rejected messages field is empty.")
+
+    chosen_encoded = sft_span_seach_mask_out(
+        {DEFAULT_SFT_MESSAGES_KEY: chosen_messages}, tokenizer, max_seq_length
+    )
+    rejected_encoded = sft_span_seach_mask_out(
+        {DEFAULT_SFT_MESSAGES_KEY: rejected_messages}, tokenizer, max_seq_length
+    )
+
+    return {
+        CHOSEN_INPUT_IDS_KEY: chosen_encoded["input_ids"],
+        CHOSEN_LABELS_KEY: chosen_encoded["labels"],
+        CHOSEN_ATTENTION_MASK_KEY: chosen_encoded["attention_mask"],
+        REJECTED_INPUT_IDS_KEY: rejected_encoded["input_ids"],
+        REJECTED_LABELS_KEY: rejected_encoded["labels"],
+        REJECTED_ATTENTION_MASK_KEY: rejected_encoded["attention_mask"],
+    }
+
+
 def rlvr_tokenize_v1(
     row: Dict[str, Any],
     tokenizer: PreTrainedTokenizer,

--- a/open_instruct/dpo_tune_cache.py
+++ b/open_instruct/dpo_tune_cache.py
@@ -156,6 +156,9 @@ class FlatArguments:
         default=None,
         metadata={"help": "The specific model version to use (can be a branch name, tag name or commit id)."},
     )
+    additional_model_arguments: Optional[Union[dict, str]] = field(
+        default_factory=dict, metadata={"help": "A dictionary of additional model args used to construct the model."}
+    )
     low_cpu_mem_usage: bool = field(
         default=False,
         metadata={

--- a/open_instruct/dpo_tune_cache.py
+++ b/open_instruct/dpo_tune_cache.py
@@ -107,13 +107,6 @@ class FlatArguments:
         "additional_model_arguments",
     ]
 
-    # Sometimes users will pass in a `str` repr of a dict in the CLI
-    # We need to track what fields those can be. Each time a new arg
-    # has a dict type, it must be added to this list.
-    # Important: These should be typed with Optional[Union[dict,str,...]]
-    # Note: the suggested ellipses typing above causes errors on python 3.10, so they are omitted.
-    _VALID_DICT_FIELDS = ["additional_model_arguments"]
-
     exp_name: str = os.path.basename(__file__)[: -len(".py")]
     """The name of this experiment"""
     run_name: Optional[str] = None
@@ -356,7 +349,7 @@ class FlatArguments:
     packing: bool = field(
         default=False,
         metadata={
-            "help": "Whether to use padding-free collation via DataCollatorWithFlatteningDPO"
+            "help": "Whether to use packing/padding-free collation via DataCollatorWithFlatteningDPO"
         },
     )
 
@@ -699,7 +692,7 @@ def main(args: FlatArguments, tc: TokenizerConfig):
 
     # DataLoaders creation:
     if args.packing:
-        accelerator.print("Using padding-free collation")
+        accelerator.print("Using packing/padding-free collation")
         collate_fn = TensorDataCollatorWithFlatteningDPO(
             return_position_ids=True, return_flash_attn_kwargs=True
         )
@@ -831,9 +824,9 @@ def main(args: FlatArguments, tc: TokenizerConfig):
     if args.packing:
         if not args.concatenated_forward: 
             raise NotImplementedError(
-                "seperate forward not implemented for padding-free"
+                "seperate forward not implemented for packing/padding-free"
             )
-        forward_fn = partial(forward_fn, padding_free=True)
+        forward_fn = partial(forward_fn, packing=True)
     if args.dpo_loss_type == "dpo" or args.dpo_loss_type == "dpo_norm":
         epoch_cached_reference_chosen_logps, epoch_cached_reference_rejected_logps = get_cache_ref_logprobs(
             model,

--- a/open_instruct/dpo_tune_cache.py
+++ b/open_instruct/dpo_tune_cache.py
@@ -159,6 +159,8 @@ class FlatArguments:
     additional_model_arguments: Optional[Union[dict, str]] = field(
         default_factory=dict, metadata={"help": "A dictionary of additional model args used to construct the model."}
     )
+    sync_each_batch: bool = False
+    """Optionaly sync grads every batch when using grad accumulation. Can significantly reduce memory costs."""
     low_cpu_mem_usage: bool = field(
         default=False,
         metadata={

--- a/open_instruct/dpo_utils.py
+++ b/open_instruct/dpo_utils.py
@@ -229,13 +229,13 @@ def concatenated_forward(
     batch: Dict[str, Union[List, torch.LongTensor]],
     average_log_prob: bool = False,
     output_router_logits: bool = False,
-    padding_free: bool = False,
+    packing: bool = False,
 ) -> Tuple[torch.FloatTensor, torch.FloatTensor]:
     """Run the given model on the given batch of inputs, concatenating the chosen and rejected inputs together.
 
     We do this to avoid doing two forward passes, because it's faster for FSDP.
     """
-    if not padding_free: 
+    if not packing: 
         concatenated_batch = concatenated_inputs(batch)
     else:
         concatenated_batch, bs = pf_concatenated_inputs(batch)
@@ -258,7 +258,7 @@ def concatenated_forward(
         ).logits.to(torch.float32)
         aux_loss = None
 
-    if not padding_free:
+    if not packing:
         all_logps = _get_batch_logps(logits, concatenated_batch["concatenated_labels"], average_log_prob=average_log_prob)
         bs = batch["chosen_input_ids"].shape[0]
     else:

--- a/open_instruct/padding_free_collator.py
+++ b/open_instruct/padding_free_collator.py
@@ -20,24 +20,10 @@ class TensorDataCollatorWithFlattening(DefaultDataCollator):
     batch size 1, with additional information included in the batch to demarcate example boundaries.
     """
 
-    def __init__(
-        self,
-        *args,
-        return_flash_attn_kwargs=True,
-        return_position_ids=True,
-        return_seq_idx=True,
-        separator_id=-100,
-        **kwargs,
-    ):
-        super().__init__(*args, **kwargs)
-        self.return_flash_attn_kwargs = return_flash_attn_kwargs
-        self.return_position_ids = return_position_ids
-        self.return_seq_idx = return_seq_idx
-        self.separator_id = separator_id
-        warnings.warn(
-            "Using `TensorDataCollatorWithFlattening` will flatten the entire mini batch into a "
-            "single long sequence. Make sure your attention computation is able to handle it!"
-        )
+    return_flash_attn_kwargs: bool = True
+    return_position_ids: bool = True
+    return_seq_idx: bool = True
+    separator_id: int = -100
 
     def __call__(self, features, return_tensors=None, separator_id=None):
         if return_tensors is None:

--- a/open_instruct/padding_free_collator.py
+++ b/open_instruct/padding_free_collator.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 
 import torch
 from transformers import DefaultDataCollator
+from typing import Dict, Union, List
 
 
 @dataclass
@@ -84,3 +85,119 @@ class TensorDataCollatorWithFlattening(DefaultDataCollator):
         ret["input_ids"] = torch.cat(ret["input_ids"], dim=0)[None]
         ret["labels"] = torch.cat(ret["labels"], dim=0)[None]
         return ret
+
+
+@dataclass
+class TensorDataCollatorWithFlatteningDPO(TensorDataCollatorWithFlattening):
+
+    def __call__(self, features, return_tensors=None):
+
+        # call the original collator on chosen and rejected separately, then combine
+        def filter_batch(match_string, features):
+            return [{k.replace(match_string, ""): v for k, v in f.items() if match_string in k} for f in features]
+
+        chosen_features = super().__call__(filter_batch("chosen_", features), return_tensors=return_tensors)
+        rejected_features = super().__call__(filter_batch("rejected_", features), return_tensors=return_tensors)
+
+        result = {}
+        for k in chosen_features:
+            result["chosen_" + k] = chosen_features[k]
+        for k in rejected_features:
+            result["rejected_" + k] = rejected_features[k]
+        return result
+
+# - dpo concatenation  for padding free
+def concatenated_inputs(
+    batch: Dict[str, Union[List, torch.LongTensor]],
+    tag: str = 'concatenated_',
+) -> Dict[str, torch.LongTensor]:
+
+    chosen_features, rejected_features = {}, {}
+    for k in batch:
+        if k.startswith('chosen_'):
+            chosen_features[k.replace("chosen_", "")] = batch[k]
+        else:
+            rejected_features[k.replace("rejected_", "")] = batch[k]
+
+    # - need to return chosen
+    ret = {
+        f'{tag}input_ids': torch.cat([chosen_features['input_ids'], rejected_features['input_ids']], axis=-1)
+    }
+    if "labels" in chosen_features:
+        ret[f'{tag}labels'] = torch.cat([chosen_features['labels'], rejected_features['labels']], axis=-1)
+
+    if "cu_seq_lens_q" in chosen_features:
+        ret[f'{tag}cu_seq_lens_q'] = torch.cat([
+            chosen_features['cu_seq_lens_q'],
+            rejected_features['cu_seq_lens_q'][1:] + chosen_features['cu_seq_lens_q'][-1],
+        ])
+        ret[f'{tag}cu_seq_lens_k'] = torch.cat([
+            chosen_features['cu_seq_lens_k'],
+            rejected_features['cu_seq_lens_k'][1:] + chosen_features['cu_seq_lens_k'][-1],
+        ])
+        ret[f'{tag}max_length_q'] = max(
+            chosen_features['max_length_q'],
+            rejected_features['max_length_q'],
+        )
+        ret[f'{tag}max_length_k'] = max(
+            chosen_features['max_length_k'],
+            rejected_features['max_length_k'],
+        )
+
+    if "position_ids" in chosen_features:
+        ret[f"{tag}position_ids"] = torch.cat([
+            chosen_features['position_ids'],
+            rejected_features['position_ids']
+        ], dim=-1)
+
+    if 'seq_idx' in chosen_features:
+        ret[f"{tag}seq_idx"] = torch.cat([
+            chosen_features['seq_idx'],
+            rejected_features['seq_idx'] + 
+            chosen_features['seq_idx'][0,-1],
+        ], dim=-1)
+
+    return ret, len(chosen_features['cu_seq_lens_k']) - 1
+
+# for dpo - padding free
+def get_batch_logps(
+    logits: torch.FloatTensor, 
+    labels: torch.LongTensor, 
+    cu_seq_lens: torch.LongTensor,
+    average_log_prob: bool = False,
+) -> torch.FloatTensor:
+
+    assert logits.shape[:-1] == labels.shape
+
+    # - we are going to get crossings at labels / logits
+    #   cont batch boundaries, but we assume that the
+    #   loss mask == True at those places
+    labels = labels[:, 1:].clone()
+    logits = logits[:, :-1, :]
+    loss_mask = labels != -100
+
+    # dummy token; we'll ignore the losses on these tokens later
+    labels[labels == -100] = 0
+
+    # there is a labels, logits shift operation above
+    cu_seq_lens = cu_seq_lens.clone() - 1
+    cu_seq_lens[0] = 0
+
+    splits = cu_seq_lens.diff().tolist()
+    per_token_logps = torch.gather(logits.log_softmax(-1), dim=2, index=labels.unsqueeze(2)).squeeze(2)
+
+    return torch.concat(
+        [
+            (
+                (ps * mask).sum(-1) / mask.sum(-1) 
+                if average_log_prob else
+                (ps * mask).sum(-1)
+            )
+            for ps, mask in 
+            zip(
+                torch.split(per_token_logps, splits, dim=-1),
+                torch.split(loss_mask, splits, dim=-1),
+            )
+
+        ]
+    )

--- a/open_instruct/utils.py
+++ b/open_instruct/utils.py
@@ -261,6 +261,8 @@ def get_datasets(
             # if dataset ends with .json or .jsonl, load from file
             if ds.endswith(".json") or ds.endswith(".jsonl"):
                 dataset = load_dataset("json", data_files=ds, split=split)
+            elif ds.endswith(".parquet"):
+                dataset = load_dataset("parquet", data_files=ds, split=split)
             else:
                 try:
                     # Try first if dataset on a Hub repo


### PR DESCRIPTION
This PR ports changes from finetune to enable DPO
- DPO data collator is copied from `padding-free` branch
- Running this branch is giving the following error:

**Reproduces previous results before moving to main**
- matches the previous result using `dpo`
- ran a new result using `dpo_norm`, looks like it doesnt perform as well as the latter (perhaps it requires new settings for `beta`)

<img width="716" alt="image" src="https://github.com/user-attachments/assets/8bfb538f-002a-4293-a556-e9df332ce206" />



<!--
```
[rank3]: Traceback (most recent call last):                                                                                                                                                                                                                                           
[rank3]:   File "/u/swanand/miniconda3/lib/python3.10/runpy.py", line 196, in _run_module_as_main                                                                                                                                                                                     
[rank3]:     return _run_code(code, main_globals, None,                                                                                                                                                                                                                               
[rank3]:   File "/u/swanand/miniconda3/lib/python3.10/runpy.py", line 86, in _run_code                                                                                                                                                                                                
[rank3]:     exec(code, run_globals)                                                                                                                                                                                                                                                  
[rank3]:   File "/proj/data-eng/swanand/dpo/dpo_rft/open-instruct/open_instruct/dpo_tune_cache.py", line 1045, in <module>
[rank3]:     main(args, tc)
[rank3]:   File "/proj/data-eng/swanand/dpo/dpo_rft/open-instruct/open_instruct/dpo_tune_cache.py", line 699, in main
[rank3]:     collate_fn = TensorDataCollatorWithFlatteningDPO(
[rank3]: TypeError: TensorDataCollatorWithFlatteningDPO.__init__() got an unexpected keyword argument 'return_position_ids'
[rank2]: Traceback (most recent call last):
[rank2]:   File "/u/swanand/miniconda3/lib/python3.10/runpy.py", line 196, in _run_module_as_main
[rank2]:     return _run_code(code, main_globals, None,
[rank2]:   File "/u/swanand/miniconda3/lib/python3.10/runpy.py", line 86, in _run_code
[rank2]:     exec(code, run_globals)
[rank2]:   File "/proj/data-eng/swanand/dpo/dpo_rft/open-instruct/open_instruct/dpo_tune_cache.py", line 1045, in <module>
[rank2]:     main(args, tc)
[rank2]:   File "/proj/data-eng/swanand/dpo/dpo_rft/open-instruct/open_instruct/dpo_tune_cache.py", line 699, in main
[rank2]:     collate_fn = TensorDataCollatorWithFlatteningDPO(
[rank2]: TypeError: TensorDataCollatorWithFlatteningDPO.__init__() got an unexpected keyword argument 'return_position_ids'
```
Removing the arguments from `TensorDataCollatorWithFlatteningDPO` gives the following error:
```
[rank0]: Traceback (most recent call last):                                                                                                                                                                                                                                           
[rank0]:   File "/u/swanand/miniconda3/lib/python3.10/runpy.py", line 196, in _run_module_as_main                                                                                                                                                                                     
[rank0]:     return _run_code(code, main_globals, None,                                                                                                                                                                                                                               
[rank0]:   File "/u/swanand/miniconda3/lib/python3.10/runpy.py", line 86, in _run_code                                                                                                                                                                                                
[rank0]:     exec(code, run_globals)                                                                                                                                                                                                                                                  
[rank0]:   File "/proj/data-eng/swanand/dpo/dpo_rft/open-instruct/open_instruct/dpo_tune_cache.py", line 1045, in <module>                                                                                                                                                            
[rank0]:     main(args, tc)                                                                                                                                                                                                                                                           
[rank0]:   File "/proj/data-eng/swanand/dpo/dpo_rft/open-instruct/open_instruct/dpo_tune_cache.py", line 828, in main                                                                                                                                                                 
[rank0]:     epoch_cached_reference_chosen_logps, epoch_cached_reference_rejected_logps = get_cache_ref_logprobs(                                                                                                                                                                     
[rank0]:   File "/proj/data-eng/swanand/dpo/dpo_rft/open-instruct/open_instruct/dpo_tune_cache.py", line 418, in get_cache_ref_logprobs                                                                                                                                               
[rank0]:     for step, batch in tqdm(enumerate(active_dataloader), disable=not accelerator.is_local_main_process):                                                                                                                                                                    
[rank0]:   File "/proj/data-eng/swanand/dpo/dpo_rft/venv/dpo_venv_v2/lib/python3.10/site-packages/tqdm/std.py", line 1181, in __iter__                                                                                                                                                
[rank0]:     for obj in iterable:                                                                                                                                                                                                                                                     
[rank0]:   File "/proj/data-eng/swanand/dpo/dpo_rft/venv/dpo_venv_v2/lib/python3.10/site-packages/accelerate/data_loader.py", line 567, in __iter__                                                                                                                                   
[rank0]:     current_batch = next(dataloader_iter)                                                                                                                                                                                                                                    
[rank0]:   File "/proj/data-eng/swanand/dpo/dpo_rft/venv/dpo_venv_v2/lib/python3.10/site-packages/torch/utils/data/dataloader.py", line 708, in __next__                                                                                                                              
[rank0]:     data = self._next_data()                                                                                                                                                                                                                                                 
[rank0]:   File "/proj/data-eng/swanand/dpo/dpo_rft/venv/dpo_venv_v2/lib/python3.10/site-packages/torch/utils/data/dataloader.py", line 764, in _next_data                                                                                                                            
[rank0]:     data = self._dataset_fetcher.fetch(index)  # may raise StopIteration                                                                                                                                                                                                     
[rank0]:   File "/proj/data-eng/swanand/dpo/dpo_rft/venv/dpo_venv_v2/lib/python3.10/site-packages/torch/utils/data/_utils/fetch.py", line 55, in fetch                                                                                                                                
[rank0]:     return self.collate_fn(data)                                                                                                                                                                                                                                             
[rank0]:   File "/proj/data-eng/swanand/dpo/dpo_rft/open-instruct/open_instruct/padding_free_collator.py", line 100, in __call__                                                                                                                                                      
[rank0]:     chosen_features = super().__call__(filter_batch("chosen_", features), return_tensors=return_tensors)
[rank0]:   File "/proj/data-eng/swanand/dpo/dpo_rft/open-instruct/open_instruct/padding_free_collator.py", line 42, in __call__
[rank0]:     separator_id = self.separator_id
[rank0]: AttributeError: 'TensorDataCollatorWithFlatteningDPO' object has no attribute 'separator_id'
```

Command used to run the code:
```
#!/usr/bin/bash
EXP_NAME="v3_dpo_test"
OUTPUT_DIR="/proj/data-eng/swanand/dpo/dpo_rft/experiment_ouputs/$EXP_NAME"
MODEL="/proj/data-eng/replaybuffer/03-models-output/01-OpenInstruct/04-G4light/01-SFT/v3-ct158-gbs128-pdbs1-lr5e6-8n-converted"
TRAINING_DATA_PATH="/proj/data-eng/replaybuffer/02-data/dpo/ultrafeedback_train_prefs.jsonl"
TRAINING_FRACTION=0.1
CHAT_TEMPLATE="/proj/data-eng/xhd/commonscript/fms-hf-tuning/src/02-chat-template/ct-granite4.jinja2"
MAX_SEQ_LENGTH=2048
LR=5e-7
LR_SCHEDULE=linear
WARMUP_RATIO=0.1
WEIGHT_DECAY=0.0
EPOCHS=1
DPO_LOSS_TYPE='dpo_norm'
DPO_BETA=5
PER_DEVICE_TRAIN_BATCH_SIZE=1
GRADIENT_ACCUMULATION_STEPS=16
GLOBAL_BATCH_SIZE=64
Z_LOSS_COEFFICIENT=0.0
SEED=42

source /proj/data-eng/swanand/dpo/dpo_rft/venv/dpo_venv_v2/bin/activate

accelerate launch $DISTRIBUTED_ARGS \
    --mixed_precision bf16 \
    --num_machines 1 \
    --num_processes 4 \
    --machine_rank 0 \
    --use_fsdp \
    --fsdp_auto_wrap_policy TRANSFORMER_BASED_WRAP \
    --fsdp_forward_prefetch False \
    --fsdp_offload_params False \
    --fsdp_backward_prefetch BACKWARD_PRE \
    --fsdp_sharding_strategy FULL_SHARD \
    --fsdp_state_dict_type FULL_STATE_DICT \
    --fsdp_cpu_ram_efficient_loading True \
    --fsdp_sync_module_states True \
    --fsdp_activation_checkpointing True \
    --dynamo_backend="no" \
    -m open_instruct.dpo_tune_cache \
    --model_name_or_path $MODEL \
    --use_slow_tokenizer False \
    --use_flash_attn \
    --max_seq_length $MAX_SEQ_LENGTH \
    --preprocessing_num_workers 16 \
    --per_device_train_batch_size $PER_DEVICE_TRAIN_BATCH_SIZE \
    --gradient_accumulation_steps $GRADIENT_ACCUMULATION_STEPS \
    --gradient_checkpointing False \
    --learning_rate $LR \
    --lr_scheduler_type $LR_SCHEDULE \
    --warmup_ratio $WARMUP_RATIO \
    --weight_decay $WEIGHT_DECAY \
    --num_train_epochs $EPOCHS \
    --output_dir $OUTPUT_DIR \
    --logging_steps 1 \
    --model_revision main \
    --try_launch_beaker_eval_jobs False \
    --dataset_mixer_list $TRAINING_DATA_PATH $TRAINING_FRACTION \
    --chat_template_name $CHAT_TEMPLATE \
    --keep_last_n_checkpoints -1 \
    --checkpointing_steps epoch \
    --padding_free True \
    --additional_model_arguments "{\"z_loss_coefficient\": $Z_LOSS_COEFFICIENT}" \
    --exp_name $EXP_NAME \
    --use_lora False \
    --push_to_hub False \
    --dpo_loss_type $DPO_LOSS_TYPE \
    --dpo_beta $DPO_BETA \
    --add_seed_and_date_to_exp_name False \
    --do_not_randomize_output_dir True \
    --dataset_transform_fn preference_span_search_mask_out preference_tulu_filter_v1 \
    --dataset_cache_mode local \
    --dataset_skip_cache False \
    --cache_dataset_only False \
    --dataset_local_cache_dir $HF_HOME \
    --seed $SEED
```

-->