### PR TITLE
Fix logits mem leak

### DIFF
--- a/open_instruct/finetune.py
+++ b/open_instruct/finetune.py
@@ -827,6 +827,8 @@ def main(args: FlatArguments, tc: TokenizerConfig):
                     if args.load_balancing_loss:
                         aux_loss = args.load_balancing_weight * outputs.aux_loss
                         loss += aux_loss
+                del outputs
+
                 # We keep track of the loss at each logged step
                 total_loss += loss.detach().float()
                 accelerator.backward(loss)


### PR DESCRIPTION
The current code leaves `logits`, `shift_logits`, and `outputs` all defined throughout every loop.  This means that references to the logits from the previous iteration are still alive while progressing through the next iteration, and so their CUDA memory cannot be freed and re-used. Logits are very memory intensive: for a 128k vocab size and 4k seqlen, `bfloat16` logits cost `1 GiB * batch_size`, so this should be avoided.

This PR deletes these references as soon as possible, thereby freeing the memory. 