### PR TITLE
Think masking

### DIFF
--- a/open_instruct/dataset_transformation.py
+++ b/open_instruct/dataset_transformation.py
@@ -1181,7 +1181,7 @@ def sft_span_seach_mask_out(
     asst_tag: str = "<|start_of_role|>assistant<|end_of_role|>",
     end_tag: str = "<|end_of_text|>",
     think_tag: str = "\n<think>\n",
-    append_think_tag: bool = False,
+    mask_think_tag: bool = False,
     ignore_label: int = -100,
 ):
     """This function encodes a single example into a format that
@@ -1267,12 +1267,11 @@ def sft_span_seach_mask_out(
         **additional_inputs,
     )
 
-    # If the user has set `append_think_tag=True` and the current sample is a thinking sample,
+    # If the user has set `mask_think_tag=True` and the current sample is a thinking sample,
     # then the <think> token is appended to the base `asst_tag` used for span matching.
     # This causes the <think> tag to be masked along with the asst_tag
-    if append_think_tag:
-        if has_thinking_content(messages):
-            asst_tag += think_tag
+    if mask_think_tag and has_thinking_content(messages):
+        asst_tag += think_tag
 
     # Assume truncation if hitting the exact max length (for downstream data filtering)
     was_truncated = input_ids.shape[1] == max_seq_length


### PR DESCRIPTION
This PR adds support for optionally appending `\n<think>\n` to the default `asst_tag` during span-based label masking for SFT — but only for samples that contain `<think>` content and when the user explicitly specifies it in the `mask_think_tag` flag. This feature is designed to additionally support models that are  **_thinking_** models, but do not specify *thinking mode* by default, and also in case the `think` and `no-think` samples are mixed in the dataset during training. 

Some assistant responses in a sample might contain a `<think>` block that represents internal monologue/reasoning by the model. During SFT, the user might not want the model to learn to *generate* the `<think>` tag itself. Instead, we optionally allow `<think>` to be treated as part of the assistant tag span boundary, so masking cleanly includes or excludes it.

The behavior is controlled by two conditions:

1. `mask_think_tag` (passed by the user)
   - `False`: masking ignores `<think>` completely.  
     - This may be because the user doesn’t want `<think>` included,  
       the model is not a “thinking” model, or for other design/training reasons.  
   - `True`: masking *may* append `<think>` to the assistant tag, depending on the passed sample's content.

2. `has_thinking_content(messages)` (sample check) 
   - Returns `True` if the assistant message:  
     - Has an explicit `thought` field, **or**  
     - Contains `"<think>"` inside its content string. 

The `<think>` suffix is appended to the assistant tag **only when both are true**:

```python
if mask_think_tag and has_thinking_content(messages):
   asst_tag += think_tag
```

**Additional notes**: 
Other minor changes:
Although it is common for `add_special_tokens` to be set to False during tokenizer encoding, we set `add_special_tokens=False` here to disable the injection of tokenizer-specific BOS/EOS or SEP tokens that would otherwise be automatically added to the encoded sequence. This is essential for correct behavior in tasks like:
- Span matching or pattern matching on tokenized control tags (e.g., <|start_of_role|>assistant<|end_of_role|>)
- Label masking for SFT or instruction tuning pipelines, where precise position tracking is required
Why is this necessary:
- By default, tokenizers for models like LLaMA, Mistral, and Phi-2 have `add_bos_token=True`, which means they automatically prepend a BOS token. This would shift all token positions by 1 and break any span matching logic.
- Other models like Qwen, etc., have `add_bos_token=False` by default, so they behave differently — leading to inconsistent behavior across model families if not explicitly handled.

